### PR TITLE
Added a z-index to header with a value higher than the elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,6 +15,7 @@ header {
     width: 100%;
     padding: 0;
     margin: 0;
+    z-index: 2;
 
 }
 
@@ -169,6 +170,7 @@ footer {grid-area: footer;}
     grid-area: coTop1;
     justify-items: center;
     align-items: center;   
+    
 }
 
 .coffee-heap img {
@@ -187,7 +189,6 @@ align-items: center;
 display: block;
 margin: 0 auto;
 height: 300px;
-background-attachment:local;
 transition: 0.2s ease;
 transform: rotate(15deg);
 }


### PR DESCRIPTION
The "Coffee Cup Falling" element seemed to be sticking ON-TOP of the header and header logo.

Fixed by adding a "z-index" with a value of 2 to the header's CSS.

This may need to be altered in the future depending on if the site requires elements with different z-indexes.