### PR TITLE
Background pixel height changed

### DIFF
--- a/style.css
+++ b/style.css
@@ -122,6 +122,7 @@ footer {grid-area: footer;}
     background-attachment: fixed;
     background-position: center;
     display: block;
+    height: 800px;
   }
 
   .parallax-blackboard {


### PR DESCRIPTION
This is a temporary fix.

Previously the background was getting cut off before the end of the page resulting in a significant white gap near the bottom.

A more permanent fix that scales to all devices correctly needs to be implanted.